### PR TITLE
Switch and bump docker-cache action to use new GH cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
           docker compose version
 
       - name: Cache docker images
-        uses: ScribeMD/docker-cache@0.3.3
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: |
             docker-${{ runner.os }}-${{ hashFiles(


### PR DESCRIPTION
See:

- ScribeMD/docker-cache#831
- ScribeMD/docker-cache#837